### PR TITLE
Fix missing file types when searching for Mod Files. Disable cheats in Dolphin starting arguments when launching Retro Rewind.

### DIFF
--- a/WheelWizard/Utils/DirectoryHandler.cs
+++ b/WheelWizard/Utils/DirectoryHandler.cs
@@ -10,20 +10,22 @@ public class DirectoryHandler
     {
         // Find the mod folder inside of the appdata mods folder
         var modFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "CT-MKWII", "Mods", mod.Title);
-    
+
         // Find the destination folder
         var destinationFolder = Path.Combine(SettingsUtils.GetLoadPathLocation(), "Riivolution", "RetroRewind6", "MyStuff");
 
         // Get all files with .szs and .brmstm extensions in the mod folder and its subfolders
         var szsFiles = Directory.GetFiles(modFolder, "*.szs", SearchOption.AllDirectories);
-        var brmstmFiles = Directory.GetFiles(modFolder, "*.brstm", SearchOption.AllDirectories);
-    
+        var arcFiles = Directory.GetFiles(modFolder, "*.arc", SearchOption.AllDirectories);
+        var brstmFiles = Directory.GetFiles(modFolder, "*.brstm", SearchOption.AllDirectories);
+        var brsarFiles = Directory.GetFiles(modFolder, "*.brsar", SearchOption.AllDirectories);
+        var thpFiles = Directory.GetFiles(modFolder, "*.thp", SearchOption.AllDirectories);
         // Create a combined list of all the files
-        var allFiles = szsFiles.Concat(brmstmFiles).ToArray();
+        var allFiles = szsFiles.Concat(arcFiles).Concat(brstmFiles).Concat(brsarFiles).Concat(thpFiles).ToArray();
 
         foreach (var file in allFiles)
         {
-            var relativePath = Path.GetFileName(file); 
+            var relativePath = Path.GetFileName(file);
             var destinationFile = Path.Combine(destinationFolder, relativePath);
             Directory.CreateDirectory(Path.GetDirectoryName(destinationFile));
             File.Copy(file, destinationFile, true);

--- a/WheelWizard/Utils/RetroRewindLauncher.cs
+++ b/WheelWizard/Utils/RetroRewindLauncher.cs
@@ -58,7 +58,7 @@ public static class RetroRewindLauncher
             Process.Start(new ProcessStartInfo
             {
                 FileName = dolphinLocation,
-                Arguments = $"-e \"{launchJson}\"",
+                Arguments = $"-e \"{launchJson}\"  --config=Dolphin.Core.EnableCheats=False",
                 UseShellExecute = false
             });
         }

--- a/WheelWizard/Views/Pages/ModsPage.xaml.cs
+++ b/WheelWizard/Views/Pages/ModsPage.xaml.cs
@@ -90,7 +90,7 @@ namespace CT_MKWII_WPF.Views.Pages
         {
             var openFileDialog = new OpenFileDialog
             {
-                Filter = "Mod files (*.zip;*.brstm;*.szs)|*.zip;*.brstm;*.szs|All files (*.*)|*.*",
+                Filter = "Mod files (*.zip;*.brstm;*.brsar;*.szs;*.arc;*.thp;)|*.zip;*.brstm;*.brsar;*.szs;*.arc;*.thp|All files (*.*)|*.*",
                 Title = "Select Mod File",
                 Multiselect = true
             };


### PR DESCRIPTION
When searching for files to load as mods only SZS and BRSTM archives were considered. This pull request introduces the missing ARC, BRSAR, and THP file filters into the related functions. 

This pull request also includes the starting argument of `--config=Dolphin.Core.EnableCheats=False` when starting Dolphin for use with Retro Rewind. I included this to prevent crashes from conflicting codes. It also doesn't require users to disable cheats in Dolphin every time they wish to launch Retro Rewind.