### PR TITLE
Create subdirectory "WheelWizard" in User/Load/Riivolution for Retro Rewind files.

### DIFF
--- a/WheelWizard/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/WheelWizard/Properties/PublishProfiles/FolderProfile.pubxml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>C:\Users\ryan\Downloads\WheelWiz</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net7.0-windows</TargetFramework>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishReadyToRun>false</PublishReadyToRun>
+  </PropertyGroup>
+</Project>

--- a/WheelWizard/Utils/DirectoryHandler.cs
+++ b/WheelWizard/Utils/DirectoryHandler.cs
@@ -12,7 +12,7 @@ public class DirectoryHandler
         var modFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "CT-MKWII", "Mods", mod.Title);
 
         // Find the destination folder
-        var destinationFolder = Path.Combine(SettingsUtils.GetLoadPathLocation(), "Riivolution", "RetroRewind6", "MyStuff");
+        var destinationFolder = Path.Combine(SettingsUtils.GetLoadPathLocation(), "Riivolution", "WheelWizard", "RetroRewind6", "MyStuff");
 
         // Get all files with .szs and .brmstm extensions in the mod folder and its subfolders
         var szsFiles = Directory.GetFiles(modFolder, "*.szs", SearchOption.AllDirectories);

--- a/WheelWizard/Utils/GameData/GameDataLoader.cs
+++ b/WheelWizard/Utils/GameData/GameDataLoader.cs
@@ -128,7 +128,7 @@ public class GameDataLoader
 
     public static byte[] LoadSaveDataFile()
     {
-        var saveFileLocation = Path.Combine(SettingsUtils.GetLoadPathLocation(), "Riivolution", "RetroRewind6", "save");
+        var saveFileLocation = Path.Combine(SettingsUtils.GetLoadPathLocation(), "Riivolution", "WheelWizard", "RetroRewind6", "save");
         var SaveFile = Directory.GetFiles(saveFileLocation, "rksys.dat", SearchOption.AllDirectories);
         if (SaveFile.Length == 0)
         {

--- a/WheelWizard/Utils/RetroRewindInstaller.cs
+++ b/WheelWizard/Utils/RetroRewindInstaller.cs
@@ -15,7 +15,7 @@ public static class RetroRewindInstaller
     public static bool IsRetroRewindInstalled()
     {
         var loadPath = SettingsUtils.GetLoadPathLocation();
-        var versionFilePath = Path.Combine(loadPath, "Riivolution", "RetroRewind6", "version.txt");
+        var versionFilePath = Path.Combine(loadPath, "Riivolution", "WheelWizard", "RetroRewind6", "version.txt");
         return File.Exists(versionFilePath);
 
     }
@@ -23,7 +23,7 @@ public static class RetroRewindInstaller
     public static string CurrentRRVersion()
     {
         var loadPath = SettingsUtils.GetLoadPathLocation();
-        var versionFilePath = Path.Combine(loadPath, "Riivolution", "RetroRewind6", "version.txt");
+        var versionFilePath = Path.Combine(loadPath, "Riivolution", "WheelWizard", "RetroRewind6", "version.txt");
         if (File.Exists(versionFilePath)) return File.ReadAllText(versionFilePath);
         return !File.Exists(versionFilePath) ? "Not Installed" : File.ReadAllText(versionFilePath);
     }
@@ -112,7 +112,7 @@ public static class RetroRewindInstaller
 private static void UpdateVersionFile(string newVersion)
 {
     var loadPath = SettingsUtils.GetLoadPathLocation();
-    var VersionFilePath = Path.Combine(loadPath, "Riivolution", "RetroRewind6", "version.txt");
+    var VersionFilePath = Path.Combine(loadPath, "Riivolution", "WheelWizard", "RetroRewind6", "version.txt");
     File.WriteAllText(VersionFilePath, newVersion);
 }
 private static async Task<List<(string Version, string Url, string Path, string Description)>> GetAllVersionData()
@@ -179,7 +179,7 @@ private static async Task<bool> DownloadAndApplyUpdate((string Version, string U
         string extratext = $"Update {currentUpdateIndex}/{totalUpdates}: {update.Description}";
         await DownloadUtils.DownloadFileWithWindow(update.Url, tempZipPath, window, extratext);
         window.UpdateProgress(100, "Extracting update...");
-        var extractionPath = Path.Combine(loadPath, "Riivolution");
+        var extractionPath = Path.Combine(loadPath, "Riivolution", "WheelWizard");
         Directory.CreateDirectory(extractionPath);
         ZipFile.ExtractToDirectory(tempZipPath, extractionPath, true);
     }
@@ -213,7 +213,7 @@ public static async Task InstallRetroRewind()
             return;
         }
         var loadPath_ = SettingsUtils.GetLoadPathLocation();
-        var rrWFC = Path.Combine(loadPath_, "Riivolution", "RetroRewind6", "save","RetroWFC");
+        var rrWFC = Path.Combine(loadPath_, "Riivolution", "WheelWizard", "RetroRewind6", "save","RetroWFC");
         if (Directory.Exists(rrWFC))
         {
             var files = Directory.GetFiles(rrWFC, "rksys.dat", SearchOption.AllDirectories);
@@ -222,12 +222,12 @@ public static async Task InstallRetroRewind()
                 var regionFolder = Path.GetDirectoryName(files[0]);
                 var regionFoldername = Path.GetFileName(regionFolder);
                 var DATFILEDATA = await File.ReadAllBytesAsync(files[0]);
-                var riiWFCregion = Path.Combine(loadPath_, "Riivolution", "riivolution", "save", "RetroWFC", regionFoldername);
+                var riiWFCregion = Path.Combine(loadPath_, "Riivolution", "WheelWizard", "riivolution", "save", "RetroWFC", regionFoldername);
                 Directory.CreateDirectory(riiWFCregion);
                 await File.WriteAllBytesAsync(Path.Combine(riiWFCregion, "rksys.dat"), DATFILEDATA);
             }
         }
-        var retroRewindPath = Path.Combine(loadPath_, "Riivolution", "RetroRewind6");
+        var retroRewindPath = Path.Combine(loadPath_, "Riivolution", "WheelWizard", "RetroRewind6");
         Directory.Delete(retroRewindPath, true);
     }
     
@@ -238,7 +238,7 @@ public static async Task InstallRetroRewind()
     await DownloadUtils.DownloadFileWithWindow(RetroRewindURL, tempZipPath, progressWindow, "Downloading Retro Rewind...");
     progressWindow.Close();
     // Extract the zip to the Riivolution folder
-    var extractionPath = Path.Combine(loadPath, "Riivolution");
+    var extractionPath = Path.Combine(loadPath, "Riivolution", "WheelWizard");
     ZipFile.ExtractToDirectory(tempZipPath, extractionPath, true);
     // Clean up the downloaded zip file
     File.Delete(tempZipPath);

--- a/WheelWizard/Utils/RetroRewindLauncher.cs
+++ b/WheelWizard/Utils/RetroRewindLauncher.cs
@@ -27,7 +27,7 @@ public static class RetroRewindLauncher
         if (mods.Length != 0)
         {
             Array.Reverse(mods);
-            var mystuffFolder = Path.Combine(SettingsUtils.GetLoadPathLocation(), "Riivolution", "RetroRewind6", "MyStuff");
+            var mystuffFolder = Path.Combine(SettingsUtils.GetLoadPathLocation(), "Riivolution", "WheelWizard", "RetroRewind6", "MyStuff");
             if (Directory.Exists(mystuffFolder))
             {
                 Directory.Delete(mystuffFolder, true);
@@ -112,7 +112,7 @@ public static class RetroRewindLauncher
         originalJSON = originalJSON.Replace("LINK TO ISO OR WBFS", correctedGamePath);
 
         // Replace the link to appdata riivolution folder with the correct path
-        string correctedRRPath = Path.Combine(SettingsUtils.GetLoadPathLocation(),"Riivolution");
+        string correctedRRPath = Path.Combine(SettingsUtils.GetLoadPathLocation(),"Riivolution", "WheelWizard");
         correctedRRPath = correctedRRPath.Replace(@"\", @"\/");
         originalJSON = originalJSON.Replace("LINK TO RIIVOLUTION FOLDER", correctedRRPath + @"\/");
 

--- a/WheelWizard/WheelWizard.csproj
+++ b/WheelWizard/WheelWizard.csproj
@@ -6,7 +6,7 @@
         <RootNamespace>CT_MKWII_WPF</RootNamespace>
         <Nullable>enable</Nullable>
         <UseWPF>true</UseWPF>
-    </PropertyGroup>
+	</PropertyGroup>
 
     <ItemGroup>
       <None Remove="Retro_Rewind_Cover.png" />
@@ -36,4 +36,5 @@
     <PropertyGroup>
         <ApplicationIcon>car-wheel.ico</ApplicationIcon>
     </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
My apologies for submitting another pull request so soon (especially with the refactor in progress) but I realized that all the Retro Rewind files were being directly extracted to User/Load/Riivolution. This could make your Riivolution folder disorganized when you have multiple Riivolution subdirectories for separate mods. This pull request creates the subdirectory "WheelWizard" inside of User/Load/Riivolution, extracting and loading all the Retro Rewind files from User/Load/Riivolution/WheelWizard instead.